### PR TITLE
Bump Security String to 2020-12-05

### DIFF
--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -106,6 +106,7 @@ $(call add_json_bool, ArtUseReadBarrier,                 $(call invert_bool,$(fi
 $(call add_json_bool, Binder32bit,                       $(BINDER32BIT))
 $(call add_json_str,  BtConfigIncludeDir,                $(BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR))
 $(call add_json_list, DeviceKernelHeaders,               $(TARGET_PROJECT_SYSTEM_INCLUDES))
+$(call add_json_str,  TargetSpecificHeaderPath,          $(TARGET_SPECIFIC_HEADER_PATH))
 $(call add_json_bool, DevicePrefer32BitApps,             $(filter true,$(TARGET_PREFER_32_BIT_APPS)))
 $(call add_json_bool, DevicePrefer32BitExecutables,      $(filter true,$(TARGET_PREFER_32_BIT_EXECUTABLES)))
 $(call add_json_str,  DeviceVndkVersion,                 $(BOARD_VNDK_VERSION))

--- a/core/tasks/check_boot_jars/package_whitelist.txt
+++ b/core/tasks/check_boot_jars/package_whitelist.txt
@@ -258,3 +258,9 @@ org\.codeaurora\.internal.*
 ###################################################
 # IFAA Manager used for Alipay and/or WeChat payment
 org\.ifaa\.android\.manager.*
+
+###################################################
+# Nvidia services
+com\.nvidia\.*
+com\.nvidia\.profilemanager\.*
+com\.nvidia\.NvCPLSvc\.*

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-01-05
+      PLATFORM_SECURITY_PATCH := 2021-02-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2020-11-05
+      PLATFORM_SECURITY_PATCH := 2020-12-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-02-05
+      PLATFORM_SECURITY_PATCH := 2021-03-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-03-05
+      PLATFORM_SECURITY_PATCH := 2021-04-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2020-12-05
+      PLATFORM_SECURITY_PATCH := 2021-01-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -651,8 +651,7 @@ function lunch()
         return 1
     fi
 
-    check_product $product
-    if [ $? -ne 0 ]
+    if ! check_product $product
     then
         # if we can't find a product, try to grab it off the LineageOS GitHub
         T=$(gettop)

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -445,7 +445,7 @@ def LoadInfoDict(input_file, repacking=False):
       elif "ro.build.thumbprint" in build_prop:
         fp = build_prop["ro.build.thumbprint"]
     if fp:
-      d["avb_salt"] = sha256(fp).hexdigest()
+      d["avb_salt"] = sha256(fp.encode()).hexdigest()
 
   return d
 


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0294   A-154915372  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0459   A-159373687  ID     High       8.0, 8.1, 9, 10
CVE-2020-0463   A-169342531  ID     High       8.0, 8.1, 9, 10, 11
CVE-2020-0464   A-150371903  ID     High       10
CVE-2020-0467   A-168500792  ID     High       8.1, 9, 10, 11
CVE-2020-0468   A-158484422  ID     High       10, 11
CVE-2020-0470   A-166268541  ID     High       10, 11
CVE-2020-15802  A-158854097  ID     High       8.0, 8.1, 9, 10, 11

Previously Implemented:
=======================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0099   A-141745510  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0458   A-160265164  RCE    Critical   8.0, 8.1, 9, 10

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0440   A-162627132  EoP    High       11
CVE-2020-0460   A-163413737  ID     High       11
CVE-2020-0469   A-168692734  DoS    High       11

Change-Id: I4172ccf129126f84050e68a14e239b7e03a22a44